### PR TITLE
Forced a minimum sidebar width to fix #3

### DIFF
--- a/panel/ncenter.vala
+++ b/panel/ncenter.vala
@@ -9,6 +9,9 @@
  * (at your option) any later version.
  */
 
+// This has been deduced empirically and may not fit all GTK themes
+const int MINIMUM_SIDEBAR_WIDTH = 300;
+
 [DBus (name="org.freedesktop.DisplayManager.Seat")]
 public interface DMSeat : Object
 {
@@ -303,6 +306,11 @@ public class NCenter : Gtk.Window
         screen.get_monitor_geometry(mon, out scr);
 
         var width = (int) (scr.width * 0.16);
+        if (width < MINIMUM_SIDEBAR_WIDTH)
+        {
+            width = MINIMUM_SIDEBAR_WIDTH;
+        }
+
         our_width = width;
         our_height = scr.height - offset;
         var y = position == Budgie.PanelPosition.TOP ? scr.y+offset : scr.y;


### PR DESCRIPTION
If determining the width relative to the screen's size, the sidebar gets
cut off on low resolutions. I therefore enforced to have at the
minimum a width of 300. This value has been determined empirically by
testing several GTK themes and resolutions. It may not be optimal!

Generally speaking a fully dynamic solution without any constant values
would be preferable. Commenting out the overridden get_preferred_width*
functions results in the container automatically adapting to the size
taken up by his children.

However I was not able to retrieve the actual width, so that it could
be utilized in placement(). I have tried get_allocated_width() and
get_size_request() without success.